### PR TITLE
Cmake dev

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,9 +117,6 @@ if (python)
     # The simple python module
     #################################################################
 
-    # hack ofr version
-    set(PACKAGE_VERSION "1.18.2")
-
     set(SETUP_PY_IN "${CMAKE_CURRENT_SOURCE_DIR}/setup_cmake_template.py")
     set(SETUP_PY "${CMAKE_CURRENT_BINARY_DIR}/setup.py")
     set(DEPS "${CMAKE_CURRENT_SOURCE_DIR}/pypolychord/__init__.py")

--- a/setup.py
+++ b/setup.py
@@ -7,15 +7,12 @@ Polychord is a tool to solve high dimensional problems.
 from setuptools import setup, Extension, find_packages, Distribution
 from setuptools.command.build_py import build_py as _build_py
 from distutils.command.clean import clean as _clean
+from setuptools.command.build_ext import build_ext
 
-import os, sys, subprocess, shutil
+import os, sys, subprocess, shutil, pathlib
 
 import numpy
 
-# Hack to use cmake on macOS ("darwin")
-if "darwin" == sys.platform:
-    os.system("mkdir build; cd build; cmake ..; make; pip install .")
-    exit()
 
 def check_compiler(default_CC="gcc"):
     """Checks what compiler is being used (clang, intel, or gcc)."""
@@ -67,6 +64,42 @@ def get_version(short=False):
             if 'version' in line:
                 return line[44:50]
 
+class CMakeExtension(Extension):
+    def __init__(self, name):
+        super().__init__(name, sources=[])
+
+class cmake_build_ext(build_ext):
+    def run(self):
+        for ext in self.extensions:
+            self.build_cmake(ext)
+        super().run()
+    
+    def build_extension(self, ext) -> None:
+        """
+        This now "builds" the extension module, by
+        copying it from the place where CMake placed it.
+        """
+        # _pypolychord.ARCH.so
+        cwd = pathlib.Path().absolute()
+        builddir = pathlib.Path(self.build_temp)
+        extpath = pathlib.Path(self.get_ext_fullpath(ext.name))
+        
+        if os.path.exists(str(cwd/builddir)):
+            shutil.copyfile(cwd/builddir/extpath.name, self.get_ext_fullpath(ext.name))
+        elif sys.argv[2] == "install":
+            # let's warn here, though this should not happen with the current CMake setup
+            print("NOT FOUND: " + cwd/extpath + "\nYour installation may be incomplete.")
+    
+    def build_cmake(self, ext):
+        print(self.build_temp)
+        cwd = pathlib.Path().absolute()
+        build_temp = pathlib.Path(self.build_temp)
+        build_temp.mkdir(parents=True, exist_ok=True)
+
+        os.chdir(str(build_temp))
+        self.spawn(["cmake", str(cwd)])
+        self.spawn(["make"])
+        os.chdir(cwd)
 
 class DistributionWithOption(Distribution, object):
     def __init__(self, *args, **kwargs):
@@ -127,20 +160,40 @@ pypolychord_module = Extension(
         sources=['pypolychord/_pypolychord.cpp']
         )
 
-setup(name=NAME,
-      version=get_version(),
-      description='Python interface to PolyChord ' + get_version(),
-      url='https://ccpforge.cse.rl.ac.uk/gf/project/polychord/',
-      author='Will Handley',
-      author_email='wh260@cam.ac.uk',
-      license='PolyChord',
-      packages=find_packages(),
-      install_requires=['numpy','scipy'],
-      extras_require={'plotting': 'getdist'},
-      distclass=DistributionWithOption,
-      ext_modules=[pypolychord_module],
-      cmdclass={'build_py' : CustomBuildPy,
-                'clean' : CustomClean},
-      package_data={"" : ["lib/libchord.so"]},
-      include_package_data=True,
-      zip_safe=False)
+if sys.platform == "darwin":
+    setup(name=NAME,
+        version=get_version(),
+        description='Python interface to PolyChord ' + get_version(),
+        url='https://ccpforge.cse.rl.ac.uk/gf/project/polychord/',
+        author='Will Handley',
+        author_email='wh260@cam.ac.uk',
+        license='PolyChord',
+        packages=find_packages(),
+        install_requires=['numpy','scipy'],
+        extras_require={'plotting': 'getdist'},
+        distclass=DistributionWithOption,
+        ext_modules=[CMakeExtension("_pypolychord")],
+
+        cmdclass={"build_ext": cmake_build_ext},
+        
+        package_data={"" : ["lib/libchord.so"]},
+        include_package_data=True,
+        zip_safe=False)
+else:
+    setup(name=NAME,
+        version=get_version(),
+        description='Python interface to PolyChord ' + get_version(),
+        url='https://ccpforge.cse.rl.ac.uk/gf/project/polychord/',
+        author='Will Handley',
+        author_email='wh260@cam.ac.uk',
+        license='PolyChord',
+        packages=find_packages(),
+        install_requires=['numpy','scipy'],
+        extras_require={'plotting': 'getdist'},
+        distclass=DistributionWithOption,
+        ext_modules=[pypolychord_module],
+        cmdclass={'build_py' : CustomBuildPy,
+                        'clean' : CustomClean},   
+        package_data={"" : ["lib/libchord.so"]},
+        include_package_data=True,
+        zip_safe=False)

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,11 @@ import os, sys, subprocess, shutil
 
 import numpy
 
+# Hack to use cmake on macOS ("darwin")
+if "darwin" == sys.platform:
+    os.system("mkdir build; cd build; cmake ..; make; pip install .")
+    exit()
+
 def check_compiler(default_CC="gcc"):
     """Checks what compiler is being used (clang, intel, or gcc)."""
 

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ class CMakeExtension(Extension):
     def __init__(self, name):
         super().__init__(name, sources=[])
 
-class cmake_build_ext(build_ext):
+class CMakeBuildExt(build_ext):
     def run(self):
         for ext in self.extensions:
             self.build_cmake(ext)
@@ -162,7 +162,7 @@ pypolychord_module = Extension(
 
 if sys.platform == "darwin":
     ext_modules = [CMakeExtension("_pypolychord")]
-    cmdclass = {"build_ext": cmake_build_ext}
+    cmdclass = {"build_ext": CMakeBuildExt}
 else:
     ext_modules = [pypolychord_module]
     cmdclass={"build_py": CustomBuildPy,

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,10 @@ import os, sys, subprocess, shutil
 
 import numpy
 
+if "darwin" == sys.platform:
+    os.system("mkdir build; cd build; cmake ..; make; pip install .")
+    exit()
+
 def check_compiler(default_CC="gcc"):
     """Checks what compiler is being used (clang, intel, or gcc)."""
 

--- a/setup.py
+++ b/setup.py
@@ -97,7 +97,7 @@ class CMakeBuildExt(build_ext):
         build_temp.mkdir(parents=True, exist_ok=True)
 
         os.chdir(str(build_temp))
-        self.spawn(["cmake", str(cwd)])
+        self.spawn(["cmake", str(cwd), f"-DPython3_EXECUTABLE={sys.executable}"])
         self.spawn(["make"])
         os.chdir(cwd)
 

--- a/setup.py
+++ b/setup.py
@@ -161,39 +161,26 @@ pypolychord_module = Extension(
         )
 
 if sys.platform == "darwin":
-    setup(name=NAME,
-        version=get_version(),
-        description='Python interface to PolyChord ' + get_version(),
-        url='https://ccpforge.cse.rl.ac.uk/gf/project/polychord/',
-        author='Will Handley',
-        author_email='wh260@cam.ac.uk',
-        license='PolyChord',
-        packages=find_packages(),
-        install_requires=['numpy','scipy'],
-        extras_require={'plotting': 'getdist'},
-        distclass=DistributionWithOption,
-        ext_modules=[CMakeExtension("_pypolychord")],
-
-        cmdclass={"build_ext": cmake_build_ext},
-        
-        package_data={"" : ["lib/libchord.so"]},
-        include_package_data=True,
-        zip_safe=False)
+    ext_modules = [CMakeExtension("_pypolychord")]
+    cmdclass = {"build_ext": cmake_build_ext}
 else:
-    setup(name=NAME,
-        version=get_version(),
-        description='Python interface to PolyChord ' + get_version(),
-        url='https://ccpforge.cse.rl.ac.uk/gf/project/polychord/',
-        author='Will Handley',
-        author_email='wh260@cam.ac.uk',
-        license='PolyChord',
-        packages=find_packages(),
-        install_requires=['numpy','scipy'],
-        extras_require={'plotting': 'getdist'},
-        distclass=DistributionWithOption,
-        ext_modules=[pypolychord_module],
-        cmdclass={'build_py' : CustomBuildPy,
-                        'clean' : CustomClean},   
-        package_data={"" : ["lib/libchord.so"]},
-        include_package_data=True,
-        zip_safe=False)
+    ext_modules = [pypolychord_module]
+    cmdclass={"build_py": CustomBuildPy,
+    "clean": CustomClean}
+
+setup(name=NAME,
+    version=get_version(),
+    description='Python interface to PolyChord ' + get_version(),
+    url='https://ccpforge.cse.rl.ac.uk/gf/project/polychord/',
+    author='Will Handley',
+    author_email='wh260@cam.ac.uk',
+    license='PolyChord',
+    packages=find_packages(),
+    install_requires=['numpy','scipy'],
+    extras_require={'plotting': 'getdist'},
+    distclass=DistributionWithOption,
+    ext_modules=ext_modules,
+    cmdclass=cmdclass,
+    package_data={"" : ["lib/libchord.so"]},
+    include_package_data=True,
+    zip_safe=False)

--- a/setup_cmake_template.py
+++ b/setup_cmake_template.py
@@ -22,6 +22,13 @@ def readme():
         return f.read()
 
 
+def get_version(short=False):
+    with open('${CMAKE_CURRENT_SOURCE_DIR}/src/polychord/feedback.f90') as f:
+        for line in f:
+            if 'version' in line:
+                return line[44:50]
+
+
 class MyBuildExtension(build_ext):
     """This class 'builds' the extension module, by
     copying it from the place where CMake placed it.
@@ -71,7 +78,7 @@ setup(name='pypolychord',
       ],
 
       # Don't touch anything below here - CMake fills this in
-      version='${PACKAGE_VERSION}',
+      version=get_version(),
       package_dir={'pypolychord': '${CMAKE_CURRENT_SOURCE_DIR}/pypolychord'},
       packages=['pypolychord'],
       cmdclass={'build_ext': MyBuildExtension},


### PR DESCRIPTION
Copied get_version() from the original `setup.py`, and added a hack to use CMake with macos ("darwin").

The hack works for `python setup.py install`, but not `pip install .` I'm not sure how to get around the numpy requirement for cmake, while still automating the numpy install.